### PR TITLE
Don't emit rooting annotations for Newick-format trees

### DIFF
--- a/tact/cli_add_taxa.py
+++ b/tact/cli_add_taxa.py
@@ -533,7 +533,7 @@ For more details, run:
 
     assert(is_binary(tree.seed_node))
     tree.ladderize()
-    tree.write(path=output + ".newick.tre", schema="newick")
+    tree.write(path=output + ".newick.tre", schema="newick", suppress_rooting=True)
     tree.write(path=output + ".nexus.tre", schema="nexus")
     print()
 

--- a/tests/test_add_taxa_integration.py
+++ b/tests/test_add_taxa_integration.py
@@ -14,7 +14,7 @@ def run_tact(script_runner, datadir, stem):
     result = script_runner.run("tact_add_taxa", "--taxonomy", taxonomy, "--backbone", backbone, "--output", ".tact-pytest-" + stem, "-vv")
     assert result.returncode == 0
     output = ".tact-pytest-" + stem + ".newick.tre"
-    tacted = Tree.get(path=output, schema="newick")
+    tacted = Tree.get(path=output, schema="newick", rooting="default-rooted")
     ss = tacted.as_ascii_plot()
     sys.stderr.write(ss)
     result = script_runner.run("tact_check_results", output, "--taxonomy", taxonomy, "--backbone", backbone, "--output", ".tact-pytest-" + stem + ".check.csv", "--cores=1")


### PR DESCRIPTION
The newick tree produced by `tact_add_taxa` (i.e., *.tacted.newick.tre) has a rooting annotation:
```
[&R] (newick tree string);
```
AFAIK such an annotation is not strictly newick-compliant. Regardless, it is giving me trouble with another tool. This PR makes it so that this annotation is not written.