### PR TITLE
Work around DendroPy ultrametricity calculations

### DIFF
--- a/tact/cli_add_taxa.py
+++ b/tact/cli_add_taxa.py
@@ -27,6 +27,7 @@ from .lib import get_new_times
 from .lib import get_short_branches
 from .lib import get_tip_labels
 from .lib import is_binary
+from .lib import update_tree_view
 
 logger = logging.getLogger(__name__)
 # Speed up logging for PyPy
@@ -367,13 +368,6 @@ def run_precalcs(taxonomy_tree, backbone_tree, min_ccp=0.8, min_extant=3, yule=F
     return mrca_rates
 
 
-def update_tree_view(tree):
-    # Stuff that DendroPy needs to keep a consistent view of the phylgoeny
-    tree.calc_node_ages()
-    tree.update_bipartitions()
-    return get_tip_labels(tree)
-
-
 @click.command()
 @click.option("--taxonomy", help="a taxonomy tree", type=click.File("r"), required=True)
 @click.option(
@@ -437,8 +431,7 @@ For more details, run:
         logger.error("Backbone tree is not binary!")
         sys.exit(1)
 
-    tree.encode_bipartitions()
-    tree.calc_node_ages()
+    update_tree_view(tree)
 
     tree_tips = get_tip_labels(tree)
     all_possible_tips = get_tip_labels(taxonomy)
@@ -564,10 +557,7 @@ For more details, run:
             new_tree = create_clade(tn, full_node_species, times)
             # Update our current MRCA node (because we might have attached to stem)
             node = graft_node(node, new_tree.seed_node, is_fully_locked(node) or ccp < min_ccp)
-            # Stuff that DendroPy needs to keep a consistent view of the phylgoeny
-            tree.calc_node_ages()
-            tree.update_bipartitions()
-            tree_tips = get_tip_labels(tree)
+            tree_tips = update_tree_view(tree)
             # Update our view of what's in the tree
             extant_species = tree_tips.intersection(species)
             # We've added this clade so pop it off our stack

--- a/tact/lib.py
+++ b/tact/lib.py
@@ -259,9 +259,19 @@ def get_tree(path, namespace=None):
     tree = dendropy.Tree.get_from_path(
         path, schema="newick", taxon_namespace=namespace, rooting="default-rooted"
     )
-    tree.calc_node_ages()
-    tree.encode_bipartitions()
+    update_tree_view(tree)
     return tree
+
+
+def update_tree_view(tree):
+    """
+    Mutates a DendroPy tree object with updated node ages and bipartition bitmask.
+
+    Returns a list of tip labels.
+    """
+    tree.calc_node_ages()
+    tree.update_bipartitions()
+    return get_tip_labels(tree)
 
 
 def is_binary(node):

--- a/tact/lib.py
+++ b/tact/lib.py
@@ -7,6 +7,7 @@ import sys
 from decimal import Decimal as D
 from math import exp
 from math import log
+from math import isclose
 
 import dendropy
 import numpy as np
@@ -281,6 +282,20 @@ def is_binary(node):
         if len(x.child_nodes()) != 2:
             return False
     return True
+
+
+def is_ultrametric(tree, tolerance=1e-6):
+    """Is the `tree` ultrametric, within a specified `tolerance`?
+
+    Uses the relative difference between minimum and maximum root-to-tip distances.
+    """
+    tree.calc_node_root_distances()
+    lengths = {}
+    for leaf in tree.leaf_node_iter():
+        lengths[leaf.taxon.label] = leaf.root_distance
+    t_min = min(lengths.items(), key=lambda x: x[1])
+    t_max = max(lengths.items(), key=lambda x: x[1])
+    return (isclose(t_min[1], t_max[1], rel_tol=tolerance), (t_min, t_max))
 
 
 def get_short_branches(node):

--- a/tact/lib.py
+++ b/tact/lib.py
@@ -265,11 +265,12 @@ def get_tree(path, namespace=None):
 
 def update_tree_view(tree):
     """
-    Mutates a DendroPy tree object with updated node ages and bipartition bitmask.
+    Mutates a DendroPy tree object with updated node ages and bipartition bitmask. We also
+    correct for minor ultrametricity errors.
 
     Returns a list of tip labels.
     """
-    tree.calc_node_ages()
+    tree.calc_node_ages(is_force_max_age=True)
     tree.update_bipartitions()
     return get_tip_labels(tree)
 


### PR DESCRIPTION
* When computing node ages, force DendroPy to always take the maximum of each node's two children's computed ages from the subtree. This also disables DendroPy's internal ultrametricity check.
* Write our own ultrametricity check based off the ape package's scaled check, which is (max - min) / max

Fixes https://github.com/jonchang/tact/issues/230.